### PR TITLE
Fix appending if object has no blacklist

### DIFF
--- a/pipeline/7_add_backgrounds/add_backgrounds.py
+++ b/pipeline/7_add_backgrounds/add_backgrounds.py
@@ -13,6 +13,7 @@ and file names.
 """
 
 import os
+from shutil import copyfile
 from random import randint
 from PIL import Image, ImageDraw, ImageFont, ImageEnhance
 
@@ -114,12 +115,20 @@ for unique_object in unique_objects:
 # For all the input images
 for x in range(0, len(image_filepaths)):
     print(image_filepaths[x])
-    if (len(blacklist[image_folderpaths[x]]) >= number_bg_folders):
-        print('You blacklisted all background types. Skipping image.')
-    else:
-        # Pick a random background
-        random_image = randint(0, len(bg_filepaths) - 1)
-        # Reroll if selected background is in the blacklist
-        while bg_folderpaths[random_image] in blacklist[image_folderpaths[x]]:
+    try:
+        if (len(blacklist[image_folderpaths[x]]) >= number_bg_folders):
+            print('You blacklisted all background types. Skipping image.')
+            copyfile('./'+images_folder_name+'/'+image_filepaths[x],
+                     './output/'+image_filepaths[x])
+            continue
+        else:
+            # Pick a random background
             random_image = randint(0, len(bg_filepaths) - 1)
+            # Reroll if selected background is in the blacklist
+            while bg_folderpaths[random_image] in \
+                blacklist[image_folderpaths[x]]:
+                random_image = randint(0, len(bg_filepaths) - 1)
+            append_background(image_filepaths[x], bg_filepaths[random_image])
+    except KeyError: # Object has no blacklist
+        random_image = randint(0, len(bg_filepaths) - 1)
         append_background(image_filepaths[x], bg_filepaths[random_image])


### PR DESCRIPTION
# Description
Fixes an issue with add_backgrounds where the script won't work if the object has no defined blacklist. Also directly copies images of objects with all backgrounds blacklisted to the output folder.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [ ] Test A
- [ ] Test B

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
